### PR TITLE
Replace tab "ready" listener with "pageshow"

### DIFF
--- a/lib/Advisor.js
+++ b/lib/Advisor.js
@@ -175,14 +175,14 @@ class Advisor {
 
   createWindowListeners() {
     tabs.on('activate', this.waitForWindow);
-    tabs.on('ready', this.waitForWindow);
+    tabs.on('pageshow', this.waitForWindow);
     tabs.on('deactivate', this.hidePanel);
     tabs.on('close', this.hidePanel);
   }
 
   removeWindowListener() {
     tabs.off('activate', this.waitForWindow);
-    tabs.off('ready', this.waitForWindow);
+    tabs.off('pageshow', this.waitForWindow);
     tabs.off('deactivate', this.hidePanel);
     tabs.off('close', this.hidePanel);
   }


### PR DESCRIPTION
This fixes an issue where the state of the url bar button would not change when a page was loaded from the cache.

@Osmose r?