### PR TITLE
Refresh panel content when page load initiated

### DIFF
--- a/lib/Advisor.js
+++ b/lib/Advisor.js
@@ -20,7 +20,7 @@ class Advisor {
   constructor() {
     this.telemetryLog = new TelemetryLog();
     const methodsToBind = ['showPanel', 'waitForWindow', 'handlePanelHide',
-                           'handlePanelShow', 'hidePanel'];
+                           'handlePanelShow', 'hidePanel', 'checkIfCached'];
     for (let key of methodsToBind) { // eslint-disable-line prefer-const
       this[key] = this[key].bind(this);
     }
@@ -112,6 +112,17 @@ class Advisor {
       button.destroy();
     }
     this.buttons = [];
+  }
+
+  // only calls waitForWindow if this page loaded from cache
+  // (ready event not fired if paged loaded from cache, so this
+  // ensures that cached pages still get notifications. pageshow fired
+  // on all page loads, so this makes sure that non-cached pages don't
+  // have waitForWindow called twice)
+  checkIfCached(tab, isCached) {
+    if (isCached) { // prevents waitForWindow from being called twice
+      this.waitForWindow();
+    }
   }
 
   // Checks that current window is target domain
@@ -209,14 +220,16 @@ class Advisor {
 
   createWindowListeners() {
     tabs.on('activate', this.waitForWindow);
-    tabs.on('pageshow', this.waitForWindow);
+    tabs.on('ready', this.waitForWindow);
+    tabs.on('pageshow', this.checkIfCached);
     tabs.on('deactivate', this.hidePanel);
     tabs.on('close', this.hidePanel);
   }
 
   removeWindowListener() {
     tabs.off('activate', this.waitForWindow);
-    tabs.off('pageshow', this.waitForWindow);
+    tabs.off('ready', this.waitForWindow);
+    tabs.off('pageshow', this.checkIfCached);
     tabs.off('deactivate', this.hidePanel);
     tabs.off('close', this.hidePanel);
   }


### PR DESCRIPTION
Previously the panel content was only refreshed when a page completed loading all elements, and whenever the active tab changed. This caused #55 to occur for sites with slow-loading page content, as the panel content wasn't refreshed until all page elements were completely loaded. 

I've added an additional "ready" listener so that the panel content is refreshed right away when a page starts loading, but without waiting for all of the 3rd party content to load. "Pageshow" is the only listener that fires when a cached page is loaded, so I needed to keep this listener as well. That created a situation where non-cached pages could have 2 panel refreshes (one with "ready" when loading starts, another with "pageshow" when loading finishes) so I have a helper method for the "pageshow" handler that only calls the method for a panel refresh if the loaded page is coming from the cache. 

@Osmose r? 