### PR TITLE
Fix #59: End the study if users agree to sign up for sync.

### DIFF
--- a/data/recommendation/notify.js
+++ b/data/recommendation/notify.js
@@ -148,7 +148,7 @@ class Notify {
     return yo`
       <footer>
         <div onclick=${this.handleNoSignup}>No thanks</div>
-        <div onclick=${this.handleSignup}>Use Firefox Sync</div>
+        <div onclick=${this.handleSignup.bind(this)}>Use Firefox Sync</div>
       </footer>
     `;
   }
@@ -171,7 +171,7 @@ class Notify {
 
   handleSignup() {
     self.port.emit('disableSite');
-    self.port.emit('signup');
+    self.port.emit('signup', this.specialOffer);
   }
 
   handleNoSignup() {

--- a/lib/Advisor.js
+++ b/lib/Advisor.js
@@ -1,23 +1,24 @@
 const { Cu } = require('chrome');
 Cu.import('resource://gre/modules/Preferences.jsm'); /* globals Preferences: false */
 
-const { AddonManager } = require('resource://gre/modules/AddonManager.jsm');
 const { Panel: panel } = require('sdk/panel');
 const request = require('sdk/request').Request;
-const self = require('sdk/self');
 const sdkData = require('sdk/self').data;
 const simpleStorage = require('sdk/simple-storage');
 const tabs = require('sdk/tabs');
 const { viewFor } = require('sdk/view/core');
+const { emit } = require('sdk/event/core');
 
 const { Button } = require('lib/Button.js');
 const { TelemetryLog } = require('lib/TelemetryLog.js');
+const { EventTarget } = require('lib/EventTarget.js');
 
 const panelWidth = 400;
 const panelHeight = 192;
 
-class Advisor {
+class Advisor extends EventTarget {
   constructor() {
+    super();
     this.telemetryLog = new TelemetryLog();
     const methodsToBind = ['showPanel', 'waitForWindow', 'handlePanelHide',
                            'handlePanelShow', 'hidePanel', 'checkIfCached'];
@@ -28,7 +29,6 @@ class Advisor {
     this.panel = this.createPanel();
     this.createRequestListeners();
     this.createWindowListeners();
-    this.checkForSync();
     Preferences.observe('services.sync.username', this.checkForSync.bind(this));
   }
 
@@ -47,6 +47,7 @@ class Advisor {
     this.panel.destroy();
     this.removeWindowListener();
     this.deleteButtons();
+    simpleStorage.storage.recData = undefined; // clear all recs
   }
 
   createPanel() {
@@ -89,8 +90,7 @@ class Advisor {
 
   checkForSync() {
     if (this.isSyncSetup()) {
-      // end study if they sign up for sync
-      this.uninstallSelf();
+      emit(this, 'sync-installed');
     }
   }
 
@@ -169,9 +169,9 @@ class Advisor {
   }
 
   createSignupListener() {
-    this.panel.port.on('signup', () => {
-      tabs.open('about:accounts?action=signup&entrypoint=menupanel');
+    this.panel.port.on('signup', specialOffer => {
       this.telemetryLog.logUIEvent('signup', this.activeRecDomain);
+      emit(this, 'signup', specialOffer);
     });
   }
 
@@ -203,14 +203,7 @@ class Advisor {
       const win = tabs.activeTab.window;
       const button = this.getButton(win);
       button.hide();
-      this.uninstallSelf();
-    });
-  }
-
-  uninstallSelf() {
-    simpleStorage.storage.recData = undefined; // clear all recs
-    AddonManager.getAddonByID(self.id, addon => {
-      addon.uninstall();
+      emit(this, 'disable-forever');
     });
   }
 

--- a/lib/EventTarget.js
+++ b/lib/EventTarget.js
@@ -1,0 +1,53 @@
+/**
+ * Drop-in replacement for {@link external:sdk/event/target.EventTarget} for use
+ * with es6 classes.
+ * @module event-target
+ * @author Martin Giger
+ * @license MPL-2.0
+ */
+ /**
+ * An SDK class that add event reqistration methods
+ * @external sdk/event/target
+ * @requires sdk/event/target
+ */
+/**
+ * @class EventTarget
+ * @memberof external:sdk/event/target
+ * @see {@link https://developer.mozilla.org/en-US/Add-ons/SDK/Low-Level_APIs/event_target#EventTarget}
+ */
+
+// slightly modified from:  https://raw.githubusercontent.com/freaktechnik/justintv-stream-notifications/master/lib/event-target.js
+
+const { on, once, off, setListeners } = require('sdk/event/core');
+
+/* istanbul ignore next */
+/**
+ * @class
+ */
+class EventTarget {
+  constructor(options) {
+    setListeners(this, options);
+  }
+
+  on(...args) {
+    on(this, ...args);
+    return this;
+  }
+
+  once(...args) {
+    once(this, ...args);
+    return this;
+  }
+
+  off(...args) {
+    off(this, ...args);
+    return this;
+  }
+
+  removeListener(...args) {
+    off(this, ...args);
+    return this;
+  }
+}
+
+exports.EventTarget = EventTarget;

--- a/lib/study.js
+++ b/lib/study.js
@@ -60,6 +60,7 @@ class SecurityAdvisorStudy extends shield.Study {
   }
 
   uninstall(reason) {
+    this.flags.dying = true;
     this.report({
       study_name: this.config.name,
       branch: this.config.variation,

--- a/lib/study.js
+++ b/lib/study.js
@@ -5,24 +5,50 @@ const { when: unload } = require('sdk/system/unload');
 
 const { Advisor } = require('./Advisor');
 
-let Advise = null;
+let advisor = null;
+let thisStudy = null;
 
+function createAdvisor(study) {
+  const newAdvisor = new Advisor();
+
+  newAdvisor.on('sync-installed', () => {
+    study.uninstall('sync-installed-inelligible');
+  });
+  newAdvisor.on('signup', specialOffer => {
+    if (specialOffer) {
+      study.uninstall('user-converted-feature-offer');
+    } else {
+      study.uninstall('user-converted-no-offer');
+    }
+  });
+  newAdvisor.on('disable-forever', () => {
+    study.uninstall('user-disabled-all-warnings');
+  });
+
+  return newAdvisor;
+}
+
+const surveyUrl = 'https://qsurvey.mozilla.com/s3/security-advisor';
 const studyConfig = {
   name: self.addonId,
-  duration: 7,
+  duration: 14,
   surveyUrls: {
-    'end-of-study': 'https://qsurvey.mozilla.com/s3/security-advisor',
-    'user-ended-study': 'https://qsurvey.mozilla.com/s3/security-advisor',
+    'end-of-study': surveyUrl,
+    'user-ended-study': surveyUrl,
+    'sync-installed-inelligible': surveyUrl,
+    'user-converted-feature-offer': surveyUrl,
+    'user-converted-no-offer': surveyUrl,
+    'user-disabled-all-warnings': surveyUrl,
     ineligible: null,
   },
   variations: {
     'regular-sync-offer'() {
-      Advise = new Advisor();
-      Advise.start({ newOffer: false });
+      advisor = createAdvisor(thisStudy);
+      advisor.start({ newOffer: false });
     },
     'new-features-sync-offer'() {
-      Advise = new Advisor();
-      Advise.start({ newOffer: true });
+      advisor = createAdvisor(thisStudy);
+      advisor.start({ newOffer: true });
     },
     'observe-only'() {},
   },
@@ -32,16 +58,29 @@ class SecurityAdvisorStudy extends shield.Study {
   isEligible() {
     return super.isEligible() && !prefSvc.isSet('services.sync.username');
   }
+
+  uninstall(reason) {
+    this.report({
+      study_name: this.config.name,
+      branch: this.config.variation,
+      study_state: reason,
+    });
+    shield.generateTelemetryIdIfNeeded().then(() => {
+      this.showSurvey(reason);
+    });
+    shield.die();
+  }
+
   cleanup() {
     if (this.variation !== 'observe-only') {
-      Advise.cleanup();
-      Advise = null;
+      advisor.cleanup();
+      advisor = null;
     }
     super.cleanup();  // cleanup simple-prefs, simple-storage
   }
 }
 
-const thisStudy = new SecurityAdvisorStudy(studyConfig);
+thisStudy = new SecurityAdvisorStudy(studyConfig);
 
 // for testing / linting
 exports.SecurityAdvisorStudy = SecurityAdvisorStudy;


### PR DESCRIPTION
Also includes some fixes for previously-existing ways for ending
the study. The Advisor class is now an EventEmitter (copied from
the SHIELD utils lib because it's not exported) and emits events
when the user agrees to the study, asks to disable it completely,
or signs up for sync while the study is running.

Because the SHIELD utils don't currently have a good way for ending
a study with a custom reason, we manually log the final telemetry
packet, trigger the survey, and end the study.

@groovecoder Are you available to r? this before the end of the week? We're hoping to push this out next Thursday and I'd like to get a copy out to S&I before the weekend. If not, just lemme know and I'll bug someone else. :D