### PR TITLE
Add Correct URL for End-of-Study Surveys

### DIFF
--- a/lib/study.js
+++ b/lib/study.js
@@ -11,8 +11,8 @@ const studyConfig = {
   name: self.addonId,
   duration: 7,
   surveyUrls: {
-    'end-of-study': 'mozilla.org',
-    'user-ended-study': 'mozilla.org',
+    'end-of-study': 'https://qsurvey.mozilla.com/s3/security-advisor',
+    'user-ended-study': 'https://qsurvey.mozilla.com/s3/security-advisor',
     ineligible: null,
   },
   variations: {


### PR DESCRIPTION
I've added the actual URL for the surveys we present to users when the study ends. Shield utils handles passing in the correct parameters in the uri (e.g. study branch, reason for ending study). 

@Osmose r? 